### PR TITLE
move scope disposal when creating command processor

### DIFF
--- a/EventSourcing/EventSourcing/Commands/Commands.cs
+++ b/EventSourcing/EventSourcing/Commands/Commands.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Immutable;
 using EventSourcing.Events;
+using EventSourcing.Internals;
 using FunicularSwitch.Extensions;
 using FunicularSwitch.Generators;
 
 namespace EventSourcing.Commands;
 
-public delegate CommandProcessor? GetCommandProcessor(Type commandType);
+public delegate ScopedCommandProcessor GetCommandProcessor(Type commandType);
 
 public abstract record Command
 {
@@ -26,7 +27,8 @@ public abstract class CommandProcessor
 	{
 		try
 		{
-			var commandProcessor = getCommandProcessor(command.GetType());
+			using var scopedCommandProcessor = getCommandProcessor(command.GetType());
+            var commandProcessor = scopedCommandProcessor.Processor;
 			var processingResult = commandProcessor != null ?
 				await commandProcessor.Process(command).ConfigureAwait(false) :
 				ProcessingResult.Unhandled(command.Id, $"No command processor registered for command {command.GetType().Name}");

--- a/EventSourcing/EventSourcing/Internals/ScopedCommandProcessor.cs
+++ b/EventSourcing/EventSourcing/Internals/ScopedCommandProcessor.cs
@@ -1,0 +1,19 @@
+﻿using EventSourcing.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventSourcing.Internals;
+
+public sealed class ScopedCommandProcessor : IDisposable
+{
+    private readonly IServiceScope scope;
+
+    public ScopedCommandProcessor(CommandProcessor? processor, IServiceScope scope)
+    {
+        this.Processor = processor;
+        this.scope = scope;
+    }
+
+    public CommandProcessor? Processor { get; }
+
+    public void Dispose() => this.scope.Dispose();
+}

--- a/EventSourcing/EventSourcing/ServiceRegistration.cs
+++ b/EventSourcing/EventSourcing/ServiceRegistration.cs
@@ -94,7 +94,7 @@ public static class ServiceCollectionExtension
 			});
 
 		foreach (var (serviceType, implementationType) in tuples)
-			serviceCollection.Add(ServiceDescriptor.Describe(serviceType, implementationType, ServiceLifetime.Scoped));
+			serviceCollection.Add(ServiceDescriptor.Describe(serviceType, implementationType, ServiceLifetime.Transient));
 
 		return serviceCollection;
 	}
@@ -110,12 +110,13 @@ public static class ServiceCollectionExtension
 			.SubscribeCommandProcessors(
 				commandType =>
 				{
-					var commandProcessorType = typeof(CommandProcessor<>).MakeGenericType(commandType);
+                    var commandProcessorType = typeof(CommandProcessor<>).MakeGenericType(commandType);
 					try
 					{
-						using var scope = provider.CreateScope();
-						return (CommandProcessor)scope.ServiceProvider.GetService(commandProcessorType);
-					}
+						var scope = provider.CreateScope();
+						var processor = (CommandProcessor?)scope.ServiceProvider.GetService(commandProcessorType);
+                        return new ScopedCommandProcessor(processor, scope);
+                    }
 					catch (Exception e)
 					{
 						provider.GetService<ILogger<Event>>()?.LogError(e,


### PR DESCRIPTION
move scope disposal when creating command processor for specific comand to after the command was processed

This is because otherwise all resolved dependencies in the scope are disposed immediately after creating the command processor, but before processing the command